### PR TITLE
Adjust APIs for paginated series queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Node modules
 node_modules
 
+# IntelliJ IDEA
+.idea
+
 # Adonis directory for storing tmp files
 tmp
 

--- a/app/Controllers/Http/TagController.js
+++ b/app/Controllers/Http/TagController.js
@@ -6,14 +6,19 @@ const { validateAll, sanitize, sanitizor } = use('Validator')
 
 class TagController {
   index({ request }) {
-    const { page = 1, order = 'id', direction = 'asc', search } = request.get()
+    const { page = 1, limit = 20, order = 'id', direction = 'asc', search, seriesType, } = request.get()
     const query = Tag.query()
 
     if (search) {
       query.where('name', 'ilike', `%${search}%`)
     }
 
-    return query.orderBy(order, direction).paginate(Number(page))
+    if(seriesType) {
+      query.whereRaw('id in (select "tag_id" from "serie_tags" ' +
+        'where "series_id" in (select "id" from "series" where "type" = ?))', [seriesType]);
+    }
+
+    return query.orderBy(order, direction).paginate(Number(page), limit)
   }
 
   async show({ params }) {


### PR DESCRIPTION
This PR complements [changes on ATC](https://github.com/lubien/atc/pull/150) to adjust paginated queries.

### Series
* Added `year`, `releaseStatus` and `tag` to possible options for filtering Series.
* Added a new parameter called `allYears` to return all available Series years.
* Removed `full` parameter, it's no longer required to return full list of Series.

### Tag
* Allow `limit` parameter to control page size
* Allow `seriesType` parameter to filter tags based on series type.

